### PR TITLE
Multiple bugfixes to get examples working again

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: CodeDepends
-Version: 0.4-1
+Version: 0.4-2
 Title: Analysis of R code for reproducible research and code comprehension
 Description: This package provides some code for analyzing R expressions
   or blocks of code and determining the dependencies between them.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: CodeDepends
-Version: 0.4-0
+Version: 0.4-1
 Title: Analysis of R code for reproducible research and code comprehension
 Description: This package provides some code for analyzing R expressions
   or blocks of code and determining the dependencies between them.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: CodeDepends
-Version: 0.3-5
+Version: 0.3-6
 Title: Analysis of R code for reproducible research and code comprehension
 Description: This package provides some code for analyzing R expressions
   or blocks of code and determining the dependencies between them.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: CodeDepends
-Version: 0.3-8
+Version: 0.4-0
 Title: Analysis of R code for reproducible research and code comprehension
 Description: This package provides some code for analyzing R expressions
   or blocks of code and determining the dependencies between them.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: CodeDepends
-Version: 0.3-6
+Version: 0.3-7
 Title: Analysis of R code for reproducible research and code comprehension
 Description: This package provides some code for analyzing R expressions
   or blocks of code and determining the dependencies between them.
@@ -13,7 +13,7 @@ License: GPL
 Depends: methods
 Imports: codetools, XML
 Suggests: graph, Rgraphviz, RUnit, knitr,  highlight, RJSONIO, RCurl
-Collate: classes.R librarySymbols.R codeDepends.R sectionDepends.R sweave.R xml.R 
+Collate: classes.R librarySymbols.R functionHandlers.R codeDepends.R sectionDepends.R sweave.R xml.R 
          jss.R frags.R codeTypes.R gc.R graph.R parallel.R 
          deps.R separateBlocks.R callGraph.R isPlot.R isOutput.R 
          refScript.R sideEffects.R 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: CodeDepends
-Version: 0.3-7
+Version: 0.3-8
 Title: Analysis of R code for reproducible research and code comprehension
 Description: This package provides some code for analyzing R expressions
   or blocks of code and determining the dependencies between them.

--- a/NEWS
+++ b/NEWS
@@ -1,0 +1,5 @@
+Changes in version 0.4.1 (2016-03-14)
+Bugfixes
+	* default loop handler now recognizes "i" spot as output
+Minor API changes
+      * created non-default ifforcomp if handler reports all inputs used within a conditional, but not conditionally created outputs, as suggested by Nick Ulle for use in compiler buildling.

--- a/R/classes.R
+++ b/R/classes.R
@@ -15,7 +15,8 @@ setClass("ScriptNodeInfo",
                          functions = 'logical', # indicating locally defined or not or NA, and the functions names are the names for the vector. #  'character',
                          removes = 'character',
                          nsevalVars = 'character',
-                         sideEffects = 'character'))
+                         sideEffects = 'character',
+                         code = "ANY"))
 
 setOldClass(c("DetailedVariableTimeline", "data.frame"))
 

--- a/R/classes.R
+++ b/R/classes.R
@@ -14,7 +14,7 @@ setClass("ScriptNodeInfo",
                          updates = 'character',
                          functions = 'logical', # indicating locally defined or not or NA, and the functions names are the names for the vector. #  'character',
                          removes = 'character',
-                         formulaVariables = 'character',
+                         nsevalVars = 'character',
                          sideEffects = 'character'))
 
 setOldClass(c("DetailedVariableTimeline", "data.frame"))

--- a/R/codeDepends.R
+++ b/R/codeDepends.R
@@ -309,7 +309,10 @@ function(e, collector = inputCollector(), basedir = ".", reset = FALSE, ...)
 {
   nodes = getInputs(e@code, collector, basedir, ...)
   # Now determine if the functions are locally defined or not, i.e. within earlier tasks in this script.
-  identifyLocalFunctions(nodes)
+  ## We don't have the whole script here, only a single node, can't (??) do the
+  ## described above. ~GB
+  ## identifyLocalFunctions(nodes)
+  nodes
 })
 
 identifyLocalFunctions =

--- a/R/codeTypes.R
+++ b/R/codeTypes.R
@@ -36,7 +36,9 @@ function(e, info = getInputs(e))
 {
 
   funs = info@functions
-  pkgs = sapply(funs, find)
+  ## format of info@functions seems to be logical indicating local
+  ## with fun names as vec names. See classes.R ~GB
+  pkgs = sapply(names(funs), find)
 
   ans = character()
   

--- a/R/deps.R
+++ b/R/deps.R
@@ -56,6 +56,7 @@ setMethod("getDependsThread", "character", function(var, info, reverse) {
                   else
                       stop("string passed to var seems to be an expression that does not appear in info")
               }
+              ## Delegate to numeric method
               getDependsThread(var = position, info = info, reverse = reverse)
           })
 
@@ -64,6 +65,12 @@ setMethod("getDependsThread", "numeric", function(var, info, reverse) {
               .getDependsThread(position = var, info = info, reverse = reverse)
 
           })
+
+
+setMethod("getDependsThread", "name", function(var, info, reverse) {
+    ## Delegate to character method
+    getDependsThread(as.character(var), info = info, reverse = reverse)
+    })
 
 .getDependsThread =
   # This is an iterative version that walks back down the

--- a/R/frags.R
+++ b/R/frags.R
@@ -67,6 +67,8 @@ function(doc, txt = readLines(doc))
       "xml"
   else if(any(grepl("^(### chunk number|<<[^>]*>>=|```\\{r.*\\})", txt)))
       "Stangled"
+  else if (any(grepl("^#\\+BEGIN_SRC R", txt, ignore.case=TRUE)))
+      "org"
   else
       "R"
 }
@@ -133,8 +135,13 @@ function(doc, txt = readLines(doc), ...)
 }
 
 
+readOrgmode =
+    function(doc, txt = readLines(doc), ...)
+{
+    
+    stop("notimplemented")
 
-
+}
 frag.readers =
   # list of functions indexed by a document type string
   # so that we can determine the type of the document
@@ -145,7 +152,8 @@ frag.readers =
         Stangled = getTangledFrags,
         R = readRExpressions,
         JSS = readJSSCode,
-        labeled = readAnnotatedScript)
+        labeled = readAnnotatedScript,
+       org = readOrgmode)
 
 
 

--- a/R/functionHandlers.R
+++ b/R/functionHandlers.R
@@ -258,6 +258,27 @@ spreadhandler = function(e, collector, basedir, input, formulaInputs, update, pi
        
 }
 
+forhandler = function(e, collector, basedir, input, formulaInputs, update, pipe = FALSE, nseval = FALSE, ...) {
+    collector$call(as.character(e[[1]]))
+    collector$vars(as.character(e[[2]]), input=FALSE)
+    getInputs(e[[3]], collector = collector, basedir = basedir, input=TRUE, update = update, pipe = pipe, nseval=FALSE, ...)
+    getInputs(e[[4]], collector = collector, basedir = basedir, input=input, update = update, pipe = pipe, nseval=FALSE, ...)
+}
+
+ifforcomp = function(e, collector, basedir, input, formulaInputs, update, pipe = FALSE, nseval = FALSE, ...) {
+    collector$calls("if")
+    getInputs(e[[2]], collector = collector, basedir = basedir, input = input, update = update, pipe = pipe, nseval=FALSE, ...)
+    
+    innerres = getInputs(e[[3]], inputCollector(functionHandlers = collector$functionHandlers))
+    collector$vars(innerres@inputs, input=TRUE)
+    collector$library(innerres@libraries)
+    collector$string(innerres@strings, basedir = basedir, filep=FALSE)
+    collector$string(innerres@files, basedir=basedir, filep=TRUE)
+    collector$calls(innerres@functions)
+    
+
+}
+
 defaultFuncHandlers = list(
     library = libreqhandler,
     require = libreqhandler,
@@ -299,6 +320,7 @@ defaultFuncHandlers = list(
     "::" = colonshandler,
     ":::" = colonshandler,
     "%>%" = pipehandler,
+    "for" = forhandler,
     "_assignment_" = assignhandler,
     "_default_" = defhandler
     

--- a/R/functionHandlers.R
+++ b/R/functionHandlers.R
@@ -2,11 +2,11 @@
 
 libreqhandler = function(e, collector, basedir, input, formulaInputs, update, pipe = FALSE,  ...)  collector$library(as.character(e[[2]]))
 
-rmhandler = function(e, collector, basedir, input, formulaInputs, update, pipe = FALSE, ...) collector$removes(sapply(e[-1], as.character))
+rmhandler = function(e, collector, basedir, input, formulaInputs, update, pipe = FALSE, nseval = FALSE, ...) collector$removes(sapply(e[-1], as.character))
 
-dollarhandler = function(e, collector, basedir, input, formulaInputs, update, pipe = FALSE, ...) collector$vars(as.character(e[[2]]), input = input)
+dollarhandler = function(e, collector, basedir, input, formulaInputs, update, pipe = FALSE, nseval = FALSE, ...) collector$vars(as.character(e[[2]]), input = input)
 
-assignhandler = function(e, collector, basedir, input, formulaInputs, update, pipe = FALSE, ...) {
+assignhandler = function(e, collector, basedir, input, formulaInputs, update, pipe = FALSE, nseval = FALSE, ...) {
     ## Do the left hand side first.
     ##if it is a simple name, then it is an output,
     ## but otherwise it is a call and may have more inputs.
@@ -24,15 +24,15 @@ assignhandler = function(e, collector, basedir, input, formulaInputs, update, pi
             collector$update(asVarName(e[[2]][[2]]))
             collector$call(paste(as.character(e[[2]][[1]]), "<-", sep = ""))
             ## needs to modify getInputs state. a bit of a sharp edge for the refactor ~GB
-            update <<- TRUE
+            update = TRUE
         }
         
         if(as.character(e[[2]][[1]]) != "$")
-            lapply(as.list(e[[2]][-c(1,2)]), getInputs, collector, basedir = basedir, input = FALSE, formulaInputs = formulaInputs, ..., update = update, pipe= pipe)
+            lapply(as.list(e[[2]][-c(1,2)]), getInputs, collector, basedir = basedir, input = FALSE, formulaInputs = formulaInputs, ..., update = update, pipe= pipe, nseval = nseval)
     }
 
     ## Do the right hand side
-    lapply(e[-c(1,2)], getInputs, collector, basedir = basedir, input = TRUE, formulaInputs = formulaInputs, update = FALSE, pipe = pipe)
+    lapply(e[-c(1,2)], getInputs, collector, basedir = basedir, input = TRUE, formulaInputs = formulaInputs, update = FALSE, pipe = pipe, nseval = nseval)
     
     if(is.name(e[[2]])) 
         collector$set(asVarName(e[[2]]))
@@ -46,14 +46,14 @@ assignhandler = function(e, collector, basedir, input, formulaInputs, update, pi
             if(!update)
                 collector$set(asVarName(e[[2]][[2]]))
             if(as.character(e[[2]][[1]]) != "$")                   
-                lapply(e[[2]][-c(1,2)], getInputs, collector, basedir = basedir, input = input, formulaInputs = formulaInputs, ..., update = update, pipe = pipe)
+                lapply(e[[2]][-c(1,2)], getInputs, collector, basedir = basedir, input = input, formulaInputs = formulaInputs, ..., update = update, pipe = pipe, nseval = nseval)
         } else {
             collector$set(asVarName(e[[2]][[2]]))
         }
     }
 }
 
-funchandler = function(e, collector, basedir, input, formulaInputs, update, pipe = FALSE, ...){
+funchandler = function(e, collector, basedir, input, formulaInputs, update, pipe = FALSE, nseval = FALSE, ...){
     tmp = eval(e)
     ans = codetools::findGlobals(tmp, FALSE)
     collector$vars(ans$variables, input = TRUE)
@@ -61,19 +61,28 @@ funchandler = function(e, collector, basedir, input, formulaInputs, update, pipe
 }
 
 
-formulahandler =  function(e, collector, basedir, input, formulaInputs, update, pipe = FALSE, ...){
+formulahandler =  function(e, collector, basedir, input, formulaInputs, update, pipe = FALSE, nseval = FALSE, ...){
     
     ## a formula, eg a~b
     ## whether we count variables that appear in formulas as inputs for the expression is controlled by the formulaInputs paramter
     ##eventually we want to be able to handle the situation where we are calling
-    ##lm(y~x + z, data=dat) where y and x are in dat but z is not, but that is HARD to detect so for now we allow users to specify whether CodeDepends counts all variables used by formulas (assuming they come from the global environment/current scope) or none (assuming the fomula will be used only within the scope of, eg, a data.frame). I think the second one is the most common use-case in practice...
+    ##lm(y~x + z, data=dat) where y and x are in dat but z is not, but that is
+    ## HARD to detect so for now we allow users to specify whether CodeDepends
+    ##counts all variables used by formulas (assuming they come from the global
+    ##environment/current scope) or none (assuming the fomula will be used only
+    ##within the scope of, eg, a data.frame). I think the second one is the most
+    ##common use-case in practice...
+
+    ## XXX port this over to the new way of dealing with nseval? ~GB
     collector$call(as.character(e[[1]]))
        if(formulaInputs)
-           lapply(e[-1], getInputs, collector, basedir = basedir, input = input, formulaInputs = formulaInputs, ..., update = update, pipe = pipe)
+           lapply(e[-1], getInputs, collector, basedir = basedir, input = input, formulaInputs = formulaInputs, ..., update = update, pipe = pipe, nseval = nseval)
        else {
                                         # collect the variables and functions in the 
            col = inputCollector()
-         lapply(e[-1], getInputs, col, basedir = basedir, input = input, formulaInputs = formulaInputs, ..., update = update, pipe = pipe)
+         lapply(e[-1], getInputs, col, basedir = basedir, input = input,
+                formulaInputs = formulaInputs, ..., update = update, pipe = pipe,
+                nseval = nseval)
          vals = col$results()
          ## format of vals@functions is named vector of NA with functions as the names
          ## logical value in return appears to indicate local or not.
@@ -84,7 +93,7 @@ formulahandler =  function(e, collector, basedir, input, formulaInputs, update, 
 
 
 
-assignfunhandler = function(e, collector, basedir, input, formulaInputs, update, pipe = FALSE, ...){
+assignfunhandler = function(e, collector, basedir, input, formulaInputs, update, pipe = FALSE, nseval = FALSE, ...){
     if(is.symbol(e[[2]])) {
         warning("assign() used with symbol as first argument. Unable to statically resolve what name the value will be assigned to")
         return()
@@ -92,49 +101,161 @@ assignfunhandler = function(e, collector, basedir, input, formulaInputs, update,
         collector$calls("assign")
         collector$set(e[[2]]) ##varable
         getInputs(e[[3]], collector = collector, basedir = basedir, input = TRUE,
-                  formulaInputs = formulaInputs, update = update, pipe = pipe, ... )
+                  formulaInputs = formulaInputs, update = update, pipe = pipe,
+                  nseval = nseval, ... )
     }
 
 }
 
-fullnsehandler = function(e, collector, basedir, input, formulaInputs, update, pipe = FALSE, ...) {
+fullnsehandler = function(e, collector, basedir, input, formulaInputs, update, pipe = FALSE, nseval = FALSE, ...) {
     collector$calls(as.character(e[[1]]))
+    lapply(e[-1], getInputs, collector = collector, basedir = basedir,
+            input = TRUE, formulaInputs = formulaInputs, update = update,
+            pipe = pipe, nseval = TRUE)
 }
 
 nseafterfirst = function(e, collector, basedir, input, formulaInputs, update,
-    pipe = FALSE, ...) {
+    pipe = FALSE, nseval = FALSE, ...) {
      collector$calls(as.character(e[[1]]))
-     if(!pipe)
+     if(!pipe) {
+         ## first argument
          getInputs(e[[2]],  collector = collector, basedir = basedir, input = TRUE,
-                   formulaInputs = formulaInputs, update = update, pipe = FALSE, ...)
+                   formulaInputs = formulaInputs, update = update, pipe = FALSE,
+                   nseval = FALSE, ...)
+         nseseq = seq(along = e)[-c(1:2)]
+     } else {
+         nseseq = seq(along = e)[-1]
+     }
+     lapply(e[nseseq], getInputs, collector = collector, basedir = basedir,
+            input = TRUE, formulaInputs = formulaInputs, update = update,
+            pipe = pipe, nseval = TRUE)
  }
 
-filterhandler = function(e, collector, basedir, input, formulaInputs, update, pipe = FALSE, ...) {
+nsehandlerfactory = function(secount) {
+    function(e, collector, basedir, input, formulaInputs, update, pipe = FALSE, nseval = FALSE, ...) {
+        if(secount == 0)
+            return(fullnsehandler)
+        seargs = 2:(1+secount)
+        if(pipe)
+            seargs = seargs[-1] #pipe gobbles the first arg
+        lapply(seargs, function(i) getInputs(e[[i]], collector = collector,
+                                             basedir = basedir, input = input,
+                                             formulaInputs = formulaInputs,
+                                             update = update, pipe = pipe,
+                                             nseval = FALSE, ...))
+        lapply(e[-seq(1, max(seargs +1))], getInputs, collector = collector,
+               basedir = basedir, input = input, formulaInputs = formulaInputs,
+               update = update, pipe = pipe, nseval = TRUE, ...)
+    }
+}
+
+
+filterhandler = function(e, collector, basedir, input, formulaInputs, update, pipe = FALSE, nseval = FALSE, ...) {
     if("dplyr" %in% collector$results()@libraries)
         nseafterfirst(e, collector, basedir = basedir, input = input,
                       formulaInputs = formulaInputs, update = update,
-                      pipe = pipe, ...)
+                      pipe = pipe, nseval = nseval, ...)
     else {
         collector$calls("filter")
-        lapply(e[-1], getInputs, col, basedir = basedir, input = input, formulaInputs = formulaInputs, ..., update = update, pipe = pipe)
+        lapply(e[-1], getInputs, col, basedir = basedir, input = input, formulaInputs = formulaInputs, ..., update = update, pipe = pipe, nseval = FALSE)
     }
 }
 
 pipehandler = function(e, collector, basedir, input, formulaInputs, update,
-    pipe = FALSE, ...) {
+    pipe = FALSE, nseval=FALSE, ...) {
     collector$calls("%>%")
     ## right-hand operand of %>%, always a function symbol or function call
     if(is.symbol(e[[3]]))
         collector$calls(as.character(e[[3]]))
     else 
-        getInputs(e[[3]], collector = collector, basedir = basedir, input = TRUE, formulaInputs = formulaInputs, update = update, pipe = TRUE)
+        getInputs(e[[3]], collector = collector, basedir = basedir, input = TRUE, formulaInputs = formulaInputs, update = update, pipe = TRUE, nseval = nseval)
     ## left hand side. leaf only if we're to the start of the expr,
     ## which won't be a function
     if(is.symbol(e[[2]])) 
         collector$vars(as.character(e[[2]]), input=TRUE)
     else
-        getInputs(e[[2]], collector = collector, basedir = basedir, input = TRUE, formulaInputs = formulaInputs, update = update, pipe = TRUE)
+        ## pipe=false because if this is a call, nothing is being passed to it
+        ## via the pipe, because this is the start
+        getInputs(e[[2]], collector = collector, basedir = basedir, input = TRUE, formulaInputs = formulaInputs, update = update, pipe = FALSE, nseval = nseval)
 
+}
+
+defhandler = function(e, collector, basedir, input, formulaInputs, update, pipe = FALSE, nseval = FALSE, ...) {
+    if(is.symbol(e[[1]])) {
+        collector$calls(as.character(e[[1]]))
+        lapply(e[-1], getInputs, collector=collector, basedir = basedir,
+               formulaInputs = formulaInputs, ..., update = update,
+               input = input, pipe = pipe, nseval = nseval)
+
+    } else if(is.call(e[[1]]) && as.character(e[[1]][[1]]) %in% c("::", ":::"))
+      { ## case of :: or :::, etc
+        getInputs(e[[1]], collector = collector, basedir = basedir,
+                  input = input, formulaInputs = formulaInputs,
+                  update = update, pipe = pipe, nseval = nseval,
+                  ...)
+        e2 = e
+        e2[[1]] = e2[[1]][[3]] # in :: and ::: calls, 1 is the colons, 2 is lib, 3 is fun
+        getInputs(e2, collector = collector, basedir = basedir,
+                  input = input, formulaInputs=  formulaInputs,
+                  update = update, pipe = pipe, nseval = nseval,
+                  ...)
+    } else {
+        lapply(e, getInputs, collector=collector, basedir = basedir,
+               formulaInputs = formulaInputs, ..., update = update,
+               input = input, pipe = pipe, nseval = nseval)
+    }
+}
+
+groupbyhandler = function(e, collector, basedir, input, formulaInputs, update, pipe = FALSE, nseval = FALSE, ...) {
+    nms = names(e)
+    add = which(nms=="add")
+    if(length(add)) {
+        getInputs(e[[add]], collector = collector,
+                  basedir = basedir, input = input, formulaInputs = formulaInputs,
+                  update = update, pipe = pipe, nseval = nseval, ...)
+        e = e[-add]
+    }
+
+    nseafterfirst(e, collector = collector, basedir = basedir, input = input,
+                  formulaInputs = formulaInputs, update = update,
+                  pipe = pipe, nseval = nseval, ...)
+
+
+}
+
+counthandler = function(e, collector, basedir, input, formulaInputs, update, pipe = FALSE, nseval = FALSE, ...) {
+    nms = names(e)
+    srt = which(nms == "sort")
+    if(length(srt)) {
+        getInputs(e[[srt]], collector = collector,
+                  basedir = basedir, input = input, formulaInputs = formulaInputs,
+                  update = update, pipe = pipe, nseval = nseval, ...)
+        e = e[-srt]
+    }
+ 
+    nseafterfirst(e, collector = collector, basedir = basedir, input = input,
+                  formulaInputs = formulaInputs, update = update,
+                  pipe = pipe, nseval = nseval, ...)
+}
+
+##filter(),mutate(),mutate_each(),transmute(),rename(),slice(),summarise(),summarize(),summarise_each(),arrange(),select(),group_by(),group_indices(),data_frame(),distinct(),do(),funs(),count()
+
+colonshandler = function(e, collector, basedir, input, formulaInputs, update, pipe = FALSE, nseval = FALSE, ...) {
+    collector$library( as.character(e[[2]]))
+    collector$call(as.character(e[[1]]))
+    collector$call(as.character(e[[3]]))
+}
+
+spreadhandler = function(e, collector, basedir, input, formulaInputs, update, pipe = FALSE, nseval = FALSE, ...) {
+    ## second and third args are nseval, rest are not.
+    collector$call("spread")
+    if(!pipe)
+        getInputs(e[[2]], collector = collector, basedir = basedir, input = input, update = update, pipe = pipe, nseval = FALSE, ...)
+
+    lapply(e[3:4], getInputs, collector = collector, basedir = basedir, input = input, update = update, pipe = pipe, nseval = TRUE, ...)
+    if(length(e) >=5)
+        lapply(e[5:length(e)], getInputs, collector = collector, basedir = basedir, input = input, update = update, pipe = pipe, nseval = FALSE, ...)
+       
 }
 
 defaultFuncHandlers = list(
@@ -149,14 +270,41 @@ defaultFuncHandlers = list(
     "function" = funchandler,
     "~" = formulahandler,
     "assign" = assignfunhandler,
-    "_assignment" = assignhandler,
     aes = fullnsehandler,
     subset = nseafterfirst,
-    transform = nseafterfirst,
+    transform = nseafterfirst, 
     filter = filterhandler,
-    "%>%" = pipehandler
+    mutate = nseafterfirst,
+    mutate_each = nsehandlerfactory(2),
+    transmute = nseafterfirst,
+    rename = nseafterfirst,
+    slice =  nseafterfirst,
+    summarise =  nseafterfirst,
+    summarize =  nseafterfirst,
+    summarise_each = nsehandlerfactory(2),
+    arrange =  nseafterfirst,
+    select =  nseafterfirst,
+    group_by = groupbyhandler,
+    group_indices =  nseafterfirst,
+    data_frame = fullnsehandler,
+    distinct =  nseafterfirst,
+    do = nseafterfirst,
+    funs = fullnsehandler,
+    count = counthandler,
+    tally = counthandler,
+    arrange = nseafterfirst,
+    spread = spreadhandler,
+    unnest = nseafterfirst,
+    with = nseafterfirst,
+    "::" = colonshandler,
+    ":::" = colonshandler,
+    "%>%" = pipehandler,
+    "_assignment_" = assignhandler,
+    "_default_" = defhandler
     
     
     )
 
 isAssignment = function(e) class(e) %in% c("=", "<-") || (is.call(e) && is.symbol(e[[1]]) && as.character(e[[1]]) == "<<-")
+
+

--- a/R/functionHandlers.R
+++ b/R/functionHandlers.R
@@ -1,0 +1,162 @@
+
+
+libreqhandler = function(e, collector, basedir, input, formulaInputs, update, pipe = FALSE,  ...)  collector$library(as.character(e[[2]]))
+
+rmhandler = function(e, collector, basedir, input, formulaInputs, update, pipe = FALSE, ...) collector$removes(sapply(e[-1], as.character))
+
+dollarhandler = function(e, collector, basedir, input, formulaInputs, update, pipe = FALSE, ...) collector$vars(as.character(e[[2]]), input = input)
+
+assignhandler = function(e, collector, basedir, input, formulaInputs, update, pipe = FALSE, ...) {
+    ## Do the left hand side first.
+    ##if it is a simple name, then it is an output,
+    ## but otherwise it is a call and may have more inputs.
+    if(!is.name(e[[2]])) {
+        
+        ## if this is a x$foo <- val or x[["foo"]] = val or x[i, j] <- val
+        ## make certain to add the variable being updated as an input.
+        ## It will also be an output. 
+        if(is.name(e[[2]][[2]]) || TRUE) { #XX Check - add TRUE to do this unconditionally.
+            if(FALSE) {
+                if(TRUE || as.character(e[[2]][[1]]) %in% c("$", "[", "[["))
+                    collector$vars(asVarName(e[[2]][[2]]), input = input)
+                collector$set(asVarName(e[[2]][[2]]))
+            }
+            collector$update(asVarName(e[[2]][[2]]))
+            collector$call(paste(as.character(e[[2]][[1]]), "<-", sep = ""))
+            ## needs to modify getInputs state. a bit of a sharp edge for the refactor ~GB
+            update <<- TRUE
+        }
+        
+        if(as.character(e[[2]][[1]]) != "$")
+            lapply(as.list(e[[2]][-c(1,2)]), getInputs, collector, basedir = basedir, input = FALSE, formulaInputs = formulaInputs, ..., update = update, pipe= pipe)
+    }
+
+    ## Do the right hand side
+    lapply(e[-c(1,2)], getInputs, collector, basedir = basedir, input = TRUE, formulaInputs = formulaInputs, update = FALSE, pipe = pipe)
+    
+    if(is.name(e[[2]])) 
+        collector$set(asVarName(e[[2]]))
+    else {
+        ## handle, e.g.
+        ##   foo(x) = 1
+        ##   x[["y"]] = 2
+        ##   x [ x > 0 ] = 2 * y
+        if(is.call(e[[2]])) {
+            ##XXX will get foo in foo(x)
+            if(!update)
+                collector$set(asVarName(e[[2]][[2]]))
+            if(as.character(e[[2]][[1]]) != "$")                   
+                lapply(e[[2]][-c(1,2)], getInputs, collector, basedir = basedir, input = input, formulaInputs = formulaInputs, ..., update = update, pipe = pipe)
+        } else {
+            collector$set(asVarName(e[[2]][[2]]))
+        }
+    }
+}
+
+funchandler = function(e, collector, basedir, input, formulaInputs, update, pipe = FALSE, ...){
+    tmp = eval(e)
+    ans = codetools::findGlobals(tmp, FALSE)
+    collector$vars(ans$variables, input = TRUE)
+    collector$calls(ans$functions)
+}
+
+
+formulahandler =  function(e, collector, basedir, input, formulaInputs, update, pipe = FALSE, ...){
+    
+    ## a formula, eg a~b
+    ## whether we count variables that appear in formulas as inputs for the expression is controlled by the formulaInputs paramter
+    ##eventually we want to be able to handle the situation where we are calling
+    ##lm(y~x + z, data=dat) where y and x are in dat but z is not, but that is HARD to detect so for now we allow users to specify whether CodeDepends counts all variables used by formulas (assuming they come from the global environment/current scope) or none (assuming the fomula will be used only within the scope of, eg, a data.frame). I think the second one is the most common use-case in practice...
+    collector$call(as.character(e[[1]]))
+       if(formulaInputs)
+           lapply(e[-1], getInputs, collector, basedir = basedir, input = input, formulaInputs = formulaInputs, ..., update = update, pipe = pipe)
+       else {
+                                        # collect the variables and functions in the 
+           col = inputCollector()
+         lapply(e[-1], getInputs, col, basedir = basedir, input = input, formulaInputs = formulaInputs, ..., update = update, pipe = pipe)
+         vals = col$results()
+         ## format of vals@functions is named vector of NA with functions as the names
+         ## logical value in return appears to indicate local or not.
+         collector$addInfo(modelVars = vals@inputs, funcNames = names(vals@functions))
+     }
+       
+}
+
+
+
+assignfunhandler = function(e, collector, basedir, input, formulaInputs, update, pipe = FALSE, ...){
+    if(is.symbol(e[[2]])) {
+        warning("assign() used with symbol as first argument. Unable to statically resolve what name the value will be assigned to")
+        return()
+    } else { ## character containing the name to assign to
+        collector$calls("assign")
+        collector$set(e[[2]]) ##varable
+        getInputs(e[[3]], collector = collector, basedir = basedir, input = TRUE,
+                  formulaInputs = formulaInputs, update = update, pipe = pipe, ... )
+    }
+
+}
+
+fullnsehandler = function(e, collector, basedir, input, formulaInputs, update, pipe = FALSE, ...) {
+    collector$calls(as.character(e[[1]]))
+}
+
+nseafterfirst = function(e, collector, basedir, input, formulaInputs, update,
+    pipe = FALSE, ...) {
+     collector$calls(as.character(e[[1]]))
+     if(!pipe)
+         getInputs(e[[2]],  collector = collector, basedir = basedir, input = TRUE,
+                   formulaInputs = formulaInputs, update = update, pipe = FALSE, ...)
+ }
+
+filterhandler = function(e, collector, basedir, input, formulaInputs, update, pipe = FALSE, ...) {
+    if("dplyr" %in% collector$results()@libraries)
+        nseafterfirst(e, collector, basedir = basedir, input = input,
+                      formulaInputs = formulaInputs, update = update,
+                      pipe = pipe, ...)
+    else {
+        collector$calls("filter")
+        lapply(e[-1], getInputs, col, basedir = basedir, input = input, formulaInputs = formulaInputs, ..., update = update, pipe = pipe)
+    }
+}
+
+pipehandler = function(e, collector, basedir, input, formulaInputs, update,
+    pipe = FALSE, ...) {
+    collector$calls("%>%")
+    ## right-hand operand of %>%, always a function symbol or function call
+    if(is.symbol(e[[3]]))
+        collector$calls(as.character(e[[3]]))
+    else 
+        getInputs(e[[3]], collector = collector, basedir = basedir, input = TRUE, formulaInputs = formulaInputs, update = update, pipe = TRUE)
+    ## left hand side. leaf only if we're to the start of the expr,
+    ## which won't be a function
+    if(is.symbol(e[[2]])) 
+        collector$vars(as.character(e[[2]]), input=TRUE)
+    else
+        getInputs(e[[2]], collector = collector, basedir = basedir, input = TRUE, formulaInputs = formulaInputs, update = update, pipe = TRUE)
+
+}
+
+defaultFuncHandlers = list(
+    library = libreqhandler,
+    require = libreqhandler,
+    requireNamespace = libreqhandler,
+    rm = rmhandler,
+    "$" = dollarhandler,
+    "=" = assignhandler,
+    "<-" = assignhandler,
+    "<<-" = assignhandler,
+    "function" = funchandler,
+    "~" = formulahandler,
+    "assign" = assignfunhandler,
+    "_assignment" = assignhandler,
+    aes = fullnsehandler,
+    subset = nseafterfirst,
+    transform = nseafterfirst,
+    filter = filterhandler,
+    "%>%" = pipehandler
+    
+    
+    )
+
+isAssignment = function(e) class(e) %in% c("=", "<-") || (is.call(e) && is.symbol(e[[1]]) && as.character(e[[1]]) == "<<-")

--- a/R/graph.R
+++ b/R/graph.R
@@ -1,3 +1,22 @@
+
+## some "var" names are not allowed as node labels
+## I know that | and || are not allowed, I guessed about some
+## other things that might also cause problems. Seems to work now ~GB
+disallowed = c("|" = "vectorized or",
+    "||" = "binary or",
+    "&&" = "binary and",
+    "&" = "vectorized and",
+    "[" = "square bracket",
+    "(" = "parenthesis",
+    "==" = "equal op",
+    "<-" = "left assign")
+makeNodeLabs = function(vars) {
+    mtch = match(vars, names(disallowed))
+    vars[!is.na(mtch)] = disallowed[mtch[!is.na(mtch)]]
+    vars
+}
+
+
 getDependsOn =
   #
   # Find what variables depend on this one variable.
@@ -28,8 +47,12 @@ function(doc, frags = readScript(doc), info = getInputs(frags), vars = getVariab
   if(!require(graph))
       stop("you need to install the graph package to create the variable graph")
   vars = unique(vars)
-  edges = structure(lapply(vars, getDependsOn, info = info, vars = vars), names = vars)
-  
+
+  edges = lapply(vars, getDependsOn, info = info, vars = vars)
+
+  ## Fix var names to be allowable node labels ~GB
+  vars = makeNodeLabs(vars)
+  names(edges) = vars
   new("graphNEL", nodes = vars, edgeL = edges, edgemode = "directed")
 }
 

--- a/inst/unitTests/.Rhistory
+++ b/inst/unitTests/.Rhistory
@@ -287,3 +287,155 @@ scr
 getInputs(scr)
 q()
 n
+library(dplyr)
+count
+data_frame
+distinct
+funs
+count
+mutate
+mutate_each
+transmut
+transmute
+rename
+slice
+summarise
+summarise_each
+arrange
+select
+group_by
+group_indices
+data_frame
+distinct
+do
+funs
+count
+source("~/gabe/checkedout/dplyr_example/load_marchmania2015.R")
+ls()
+group_by
+sapply(parse(text="c(x, y=5, z=w+5)"), names)
+count
+?count
+q()
+n
+library(CodeDepends)
+scr = readScript("~/gabe/checkedout/dplyr_example/load_marchmania2015.R")
+scr
+getInputs(scr)
+options(error=recover)
+getInputs(scr)
+body()
+update
+2
+update
+ls()
+ls()
+q()
+n
+library(CodeDepends)
+scr = readScript("~/gabe/checkedout/dplyr_example/load_marchmania2015.R")
+scr
+getInputs(scr)
+scr[[69]]
+library(devtools)
+install("~/gabe/checkedout/CodeDepends")
+q()
+n
+library(CodeDepends)
+scr = readScript("~/gabe/checkedout/dplyr_example/load_marchmania2015.R")
+ins
+scr[[64]]
+ins[[64]]
+last
+debug(getInputs.language)
+debug(CodeDepends:::getInputs.language)
+getInputs(scr[[64]])
+trace(getInputs.language, where = "package:CodeDepends")
+trace(getInputs, browser, signature="ANY")
+getInputs(scr[[64]])
+n
+n
+debug(.local)
+n
+e
+c
+n
+n
+n
+e
+c
+e
+ls()
+list(...)
+Q
+q()
+n
+library(dplyr)
+summarise
+dplyr:::summarise_
+methods("summarise_")
+dplyr:::summarise_.data.frame
+dplyr:::summarise_.tbl_df
+dplyr:::summarise_impl
+?summarise
+n_distinct
+first
+last
+n
+q()
+n
+q()
+n
+`::`
+class(parse(text = "dplyr::summarise"))
+class(parse(text = "dplyr::summarise")[[1]])
+estuff = parse(text = "dplyr::summarise")[[1]]
+estuff[[1]]
+estuff[[2]]
+estuff = parse(text = "dplyr::summarise(x,y,thang")[[1]]
+estuff = parse(text = "dplyr::summarise(x,y,thang)")[[1]]
+estuff
+estuff[[3]]
+estuff[[1]]
+estuff[[1]][[1]]
+estuff[[1]][[3]]
+estuff[[1]][[4]]
+length(estuff)
+estuff
+estuff[[1]]
+estuff[[2]]
+class(estuff[[1]])
+q()
+n
+library(CodeDepends)
+readScript
+rnorm
+getwd()
+library(CodeDepends)
+scr = readScript("testcode/inputtest5.R")
+scr
+getInputs(scr)
+stuff = parse(text="stats::rnorm(x,y)")
+stuff[[1]]
+stuff = parse(text="stats::rnorm(x,y)")[[1]]
+length(stuff)
+stuff[[3]]
+stuff[[2]]
+stuff[[1]]
+classt(stuff)
+class(stuff)
+class(e[[1]])
+class(stuff[[1]])
+as.character(stuff)
+stuff[[1]]
+stuff[[1]][[1]]
+stuff[[1]][[2]]
+q()
+n
+library(CodeDepends)
+library(RUnit)
+scr
+src
+res
+q()
+n

--- a/inst/unitTests/.Rhistory
+++ b/inst/unitTests/.Rhistory
@@ -1,41 +1,3 @@
-list.files(recursive=TRUE)
-scr
-getInputs(scr)
-debug(getInputs.language)
-debug(CodeDepends:::getInputs.language)
-getInputs(scr)
-class(scr)
-trace(getInputs, browser, signature="Script")
-getInputs(scr)
-n
-e
-class(e[[1]])
-trace(CodeDepends:::getInputs.language, browser)
-n
-n
-ans
-c
-library(DynDocModel)
-q()
-n
-library(CodeDepends)
-library(RUnit)
-}
-"
-"
-'
-;
-library(CodeDepends)
-library(RUnit)
-res
-q()
-n
-library(CodeDepends)
-library(RUnit)
-objects("package:CodeDepends")
-serialize
-?serialize
-x = serialize(list(1, 2, 3))
 x = serialize(list(1, 2, 3), NULL)
 x
 ?hash
@@ -439,3 +401,100 @@ src
 res
 q()
 n
+library(CodeDepends)
+res
+readLines("testcode/inputtest1.R")
+library(RUnit)
+res
+}
+scr
+scr2
+ls()
+res
+scr
+scr = readScript("../examples/disjoint.R")
+getwd()
+scr = readScript("../samples/disjoint.R")
+scr
+info = getInputs(scr)
+info
+length(info)
+getDependsThread("z", info = info)
+getDependsThread("z", info = info)
+info
+getDependsThread
+getDependsThread("w", info, TRUE)
+trace(getDependsThread, signature = "character", browser)
+getDependsThread("w", info, TRUE)
+n
+n
+expr
+n
+n
+position
+var
+debug(findLastDef)
+findLastDef("z", info)
+c
+c
+getDependsThread("z", info, TRUE)
+c
+c
+getDependsThread("z", info, TRUE)
+n
+n
+n
+w
+n
+n
+last
+n
+Q
+getDependsThread("z", info, TRUE)
+c
+scr
+getDependsThread(7, info = info)
+getDependsThread("foo(o)", info = info)
+c
+info
+info[[7]]@code
+class(info[[7]]@code)
+e = parse(text = "foo(o)")
+e
+e[[1]]
+identical(info[[7]]@code, e[[1]])
+getDependsThread("foo(o)", info = info)
+getDependsThread(9)
+getDependsThread(9, info = info)
+getDependsThread("z", info = info)
+write_PACKAGES
+library(tools)
+write_PACKAGES
+tools:::.build_repository_package_db
+thing = read.dcf("http://restst.gene.com/gran/devel/src/contrib/PACKAGES")
+thing = read.dcf(url("http://restst.gene.com/gran/devel/src/contrib/PACKAGES"))
+thing
+colnames(thing)
+;lajkdf
+library(CodeDepends)
+things = lapply(list.files("~/gabe/checkedout/SlothClient/R/", pattern = ".R$", full.names=TRUE), readScript)
+length(things)
+things
+stuffnstuff = lapply(things, getInputs)
+stuffnstuff
+allfuns = unique(unlist(lapply(stuffnstuff, function(x) x@functions)))
+allfuns = unique(unlist(lapply(stuffnstuff, function( y) lapply(y, function(x) x@functions))))
+allfuns
+allfuns = unique(unlist(lapply(stuffnstuff, function( y) lapply(y, function(x) names(x@functions)))))
+allfuns
+allfuns = unique(unlist(lapply(stuffnstuff, function( y) lapply(y, function(x) names(x@functions)[x@functions]))))
+allfuns
+allfuns = unique(unlist(lapply(stuffnstuff, function( y) lapply(y, function(x) names(x@functions)[!x@functions]))))
+allfuns
+any(c("exit", "fork", "getpid", "handleSIGCLD", "kill", "killall", "restorSIGCLD", "signal", "signame", "sigval", "siglist", "wait") %in% allfuns)
+q()
+n
+q()
+n
+q()
+n 

--- a/inst/unitTests/.Rhistory
+++ b/inst/unitTests/.Rhistory
@@ -148,3 +148,142 @@ inputCollector
 CodeDepends:::inputCollector
 q()
 n
+library(CodeDepends)
+library(RUnit)
+test_formula()
+options(error=recoveR)
+options(error=recover)
+test_formula()
+ls()
+formulaInputs
+e
+q
+Q
+lapply(CodeDepends:::defaultFuncHandlers, trace)
+test_formula()
+0
+q()
+n
+library(CodeDepends)
+library(RUnit)
+test_formula()
+test_altoutput()
+w = parse("assign('x', 5)")
+w = parse(text="assign('x', 5)")
+w
+sapply(w, class)
+sapply(w[[1]], class)
+assign
+?assign
+z = parse(text="x<<-5")
+z
+sapply(z[[1]], class)
+l = "x"
+stuff = parse(text="assign(l, 5)")
+sapply(stuff, class)
+sapply(stuff[[1]], class)
+is.name
+is.symbol
+q()
+n
+q(*)
+q()
+n
+options(error=recover)
+test_libsymbols()
+body()
+q()
+n
+q()
+n
+library(ggplot2)
+?aes
+?transform
+help(transform, package="ggplot2")
+?transform
+?subset
+?library(dplyr)
+?filter
+dplyr:::filter
+help("filter", "dplyr")
+vignette("nse")
+?filter
+p = parse(text="a %>% b %>% c %>% d")
+p
+sapply(p, class)
+sapply(p[[1]], class)
+p[[1]]
+p[[1]][[1]]
+p[[1]][[2]]
+p[[1]][[3]]
+p[[1]][[4]]
+q()
+n
+"df %>% a %>% b %>% c"
+txt = "df %>% a %>% b %>% c"
+library(CodeDepends)
+scr = readScript(,txt = txt)
+scr
+getInputs(scr)
+getInputs(scr, "%>%" = CodeDepends:::pipehandler)
+getInputs(scr, CodeDepends:::inputCollector("%>%" = CodeDepends:::pipehandler))
+scr
+debug(CodeDepends:::pipehandler)
+getInputs(scr, CodeDepends:::inputCollector("%>%" = CodeDepends:::pipehandler))
+n
+e[[3]]
+e[[2]]
+n
+n
+n
+n
+getInputs(scr, CodeDepends:::inputCollector("%>%" = CodeDepends:::pipehandler))
+n
+n
+n
+class(e[[2]])
+debug(getInputs)
+n
+n
+n
+n
+debug(getInputs.language)
+n
+getInputs(scr, CodeDepends:::inputCollector("%>%" = CodeDepends:::pipehandler))
+c
+c
+c
+c
+undebug(getInputs)
+trace(getInputs, browser, signature="ANY")
+getInputs(scr, CodeDepends:::inputCollector("%>%" = CodeDepends:::pipehandler))
+n
+n
+debug(.local)
+n
+e
+n
+n
+n
+n
+n
+n
+as.character(e[[1]])
+n
+n
+n
+n
+n
+debug(.local)
+n
+e
+Q
+q()
+n
+txt = "df %>% a %>% b %>% c"
+library(CodeDepends)
+scr = readScript(,txt = txt)
+scr
+getInputs(scr)
+q()
+n

--- a/inst/unitTests/doTests.R
+++ b/inst/unitTests/doTests.R
@@ -1,7 +1,7 @@
 library(RUnit)
 library(CodeDepends)
 
-testSuite = defineTestSuite(name = "DynDocModelTests",
+testSuite = defineTestSuite(name = "CodeDepends",
   dirs = getwd(),
   testFileRegexp="^test.*\\.R$",
   testFuncRegexp="^test.*")

--- a/inst/unitTests/test_inputoutput.R
+++ b/inst/unitTests/test_inputoutput.R
@@ -42,3 +42,33 @@ test_libsymbols = function()
         checkTrue("f" %in% res[[5]]@inputs, "code-defined function f not detected as input when called by subsequent code")
     }
         
+
+sameset = function(x,y) {
+    if(!is.vector(x) || !is.vector(y))
+        stop("x,y need to be vectors")
+    if(!identical(class(x), class(y)))
+        return(FALSE)
+    identical(sort(unique(x)), sort(unique(y)))
+}
+
+
+test_colons = function() {
+    scr = readScript(,txt = "stats::rnorm(n, x)")
+    inp = getInputs(scr)[[1]]
+    checkTrue(sameset(names(inp@functions), c("::", "rnorm")), "Not identifying functions correctly in double colon calls")
+    checkTrue(sameset(inp@inputs, c("n", "x")), "Not identifying inputs correctly in double colon calls")
+    checkTrue(sameset(inp@libraries, c("stats")), "Did not correctly identify libraries used via ::")
+}
+
+
+test_pipe = function() {
+    scr = readScript("testcode/inputtest5.R")
+    res = getInputs(scr)[[1]]
+    checkTrue(sameset(names(res@functions), c("%>%", "::", paste0("f", 1:4))),
+              "Did not correctly identify functions called via pipe")
+    checkTrue(sameset(res@libraries, c("stats", "graphics")), "Didn't catch libraries called via :: within pipe expression")
+    checkTrue(sameset(res@inputs, c("df", "w", "z")), "Didn't correctly id initial and additional inputs to pipe expression")
+    checkIdentical(res@outputs, "out", "Didn't correctly identify output of -> in pipe expression")
+    
+
+}

--- a/inst/unitTests/testcode/inputtest5.R
+++ b/inst/unitTests/testcode/inputtest5.R
@@ -1,0 +1,1 @@
+df %>% f1 %>% f2(opt = z) %>% stats::f3 %>% graphics::f4(opt2 = w, opt3 = "hi") -> out

--- a/man/Script-class.Rd
+++ b/man/Script-class.Rd
@@ -83,7 +83,7 @@ Class \code{"\linkS4class{vector}"}, by class "list", distance 2.
  info = getInputs(sc, basedir = dirname(f))
 
    # Providing our own handler for calls to source()
- sourceHandler = function(e, collector = NULL, basedir = ".") {
+ sourceHandler = function(e, collector = NULL, basedir = ".", ...) {
      collector$string(e[[2]], , TRUE)
      collector$calls(as.character(e[[1]]))
  }

--- a/man/inputCollector.Rd
+++ b/man/inputCollector.Rd
@@ -133,7 +133,7 @@ FALSE, checkLibrarySymbols = FALSE, funcsAsInputs = checkLibrarySymbols)
 \examples{
    f = system.file("samples", "results-multi.R", package="CodeDepends")
    sc = readScript(f)
-  collector = inputCollector(library = function(e, collector, basedir)
+  collector = inputCollector(library = function(e, collector, basedir, ...)
   {
     print(paste("loaded library",  e[[2]]))
     collector$library(as.character(e[[2]]))


### PR DESCRIPTION
- Some code still expected scr@functions to be a character, rather than named logical. fixed.
- Graph objects can't have node names that contain "|", and possibly other things. fixed
- identifyLocalFunctions was being called when getInputs was called on a single node. AFAICS, that doesn't make any sense without the whole script, and was breaking. Removed call when getInputs is called on single node rather than full script.
