### PR TITLE
Fixing error when makeCallGraph with package with no closure functions

### DIFF
--- a/R/callGraph.R
+++ b/R/callGraph.R
@@ -80,7 +80,10 @@ setMethod("makeCallGraph", "list",
             require(graph)
             ids = funNames
             edges = lapply(obj, function(f) {
-                                  calls = findGlobals(f, merge = FALSE)$functions
+                                  calls <- character(0)
+                                  if (typeof(f) == "closure") {
+                                      calls <- findGlobals(f, merge = FALSE)$functions
+                                  }
                                   if(all)
                                     return(calls)
                                   list(edges = match(calls[calls %in% ids], ids))


### PR DESCRIPTION
If `makeCallGraph` is called with a package name, e.g., `package:magrittr` it fails as this package contains some functions that are not closures:

```r
library("CodeDepends")
library("magrittr")
makeCallGraph("package:magrittr")
```

    # Error in makeUsageCollector(fun, ...) : only works for closures 

this happens because we are calling `findGlobals` with a non-closure. I have fixed this, by assigning that a non-closure function calls `character(0)` functions.