### PR TITLE
add biocViews to DESCRIPTION to enable install of graph from bioconductor (ref #30).

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,6 +13,7 @@ License: GPL
 URL: https://github.com/duncantl/CodeDepends
 BugReports: https://github.com/duncantl/CodeDepends/issues
 Depends: methods
+biocViews:
 Imports: codetools, graph, XML, utils
 Suggests: Rgraphviz, RUnit, knitr,  highlight, RJSONIO, RCurl, Rcpp
 VignetteBuilder: knitr


### PR DESCRIPTION
Hi,

We've recently had [a package submitted for rOpenSci review, `Rclean`,](https://github.com/ropensci/software-review/issues/327) that depends on this package. Unfortunately, the `graph` dependency, identified as an issue in #30  is causing problems as review requires that packages can be fully installed from source code using `devtools::install()` (unless they have some System dependencies whose install can't be automated).

I've  added `biocViews:` to the `DESCRIPTION` file, as suggested in [this comment](https://github.com/duncantl/CodeDepends/issues/30#issuecomment-376161786) and by changing the remote repository pointer in `Rclean` to install my fork of `CodeDepends`, installation of all dependencies, including `graph` succeeds. 

This setup installs version 1.62 of `graph` which I believe is the latest version? 

Hope this helps.